### PR TITLE
Update zip7.py

### DIFF
--- a/sflock/unpack/zip7.py
+++ b/sflock/unpack/zip7.py
@@ -64,7 +64,8 @@ class Zip7File(Unpacker):
         else:
             filepath = self.f.temp_path(b".7z")
             temporary = True
-
+        if not password:
+            password = b""
         ret = self.zipjail(filepath, dirpath, "x", "-mmt=off", "-p{}".format(password.decode("utf-8")), "-o{}".format(dirpath), filepath)
         if not ret:
             return []


### PR DESCRIPTION
In cases where slfock iterates because the zip contains another "container" item, such as a zip or office file, the password becomes 'None' and fails to decode.