### PR TITLE
fix package installation when dependencies aren't already installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,19 @@
 # This file is part of SFlock - http://www.sflock.org/.
 # See the file 'docs/LICENSE.txt' for copying permission.
 
-from setuptools import setup
-from sflock import __version__
+from setuptools import setup, find_packages
+from distutils.util import convert_path
+
+ver_module_ns = {}
+ver_module = convert_path('sflock/__version__.py')
+with open(ver_module) as fh:
+    exec(fh.read(), ver_module_ns)
+assert '__version__' in ver_module_ns
+version = ver_module_ns['__version__']
 
 setup(
     name="SFlock",
-    version=__version__,
+    version=version,
     author="Hatching B.V.",
     author_email="jbr@hatching.io",
     packages=[

--- a/sflock/__init__.py
+++ b/sflock/__init__.py
@@ -5,5 +5,4 @@
 from sflock.compat import magic
 from sflock.exception import UnpackException
 from sflock.main import ident, unpack, supported, zipify
-
-__version__ = "0.3.13"
+from sflock.__version__ import __version__

--- a/sflock/__version__.py
+++ b/sflock/__version__.py
@@ -1,0 +1,2 @@
+# Only set __version__ here; this module is executed by setup.py via exec().
+__version__ = "0.3.13"


### PR DESCRIPTION
Follow-up to 9a0d88b, read version from a module to let Pip's dependency management work.

Pip doesn't process dependencies correctly when using the pattern in 9a0d88b. You can reproduce the failure like this:

```shell
python3 -m venv venv-9a0d88b
. venv-9a0d88b/bin/activate
pip3 install git+https://github.com/doomedraven/sflock.git@9a0d88b
```