### PR TITLE
do not fail on encrypted office documents

### DIFF
--- a/sflock/unpack/office.py
+++ b/sflock/unpack/office.py
@@ -16,7 +16,10 @@ class OfficeFile(Unpacker):
         if password is None:
             return
 
-        return plugins["office"](self.f, password).decode()
+        try:
+            return plugins["office"](self.f, password).decode()
+        except:
+            return
 
     def unpack(self, password=None, duplicates=None):
         # Avoiding recursive imports. TODO Can this be generalized?


### PR DESCRIPTION
This change set allows encrypted maldocs (e.g. .xlsx) with one password to be extracted from password protected archives with another password (e.g. .zip).

An example would be a .zip with the password of `infected` where the corresponding .xlsx document uses the well-known password `VelvetSweatshop`. An example could be found here: https://bazaar.abuse.ch/sample/1b09401fa79210a9667d030ca4b6960d468fd57697f7e8b5163f5d5d9b7d26d2/