### PR TITLE
Golang files get ps1 and vbs package due to some string's inside

### DIFF
--- a/sflock/ident.py
+++ b/sflock/ident.py
@@ -229,6 +229,9 @@ def office_ole(f):
 
 
 def powershell(f):
+    if f.contents[:2] == b'MZ':
+        return None
+
     POWERSHELL_STRS = [
         b"$PSHOME",
         b"Get-WmiObject",
@@ -299,6 +302,9 @@ def pub(f):
 
 
 def visualbasic(f):
+    if f.contents[:2] == b'MZ':
+        return None
+
     VB_STRS = [
         b"Dim ",
         b"dim ",


### PR DESCRIPTION
it can be fixed also with change the if order:
check magics first and then identifiers