### PR TITLE
Since UDF is based on YARA rules, it should be one of the first identifiers to run

### DIFF
--- a/sflock/ident.py
+++ b/sflock/ident.py
@@ -500,6 +500,7 @@ def identify(f, check_shellcode: bool = False):
 
 
 identifiers = [
+    udf,
     dmg,
     office_zip,
     office_ole,
@@ -517,5 +518,4 @@ identifiers = [
     vbe_jse,
     sct,
     inp,
-    udf,
 ]


### PR DESCRIPTION
The contents of some UDF files can expose the contents of their embedded files. I'll send you a UDF file on Slack that is identified as a JavaScript file by SFlock2 when it is really a UDF file that contains a JavaScript file.