### PR TITLE
Adding trusted mime types for iso archives

### DIFF
--- a/sflock/ident.py
+++ b/sflock/ident.py
@@ -89,6 +89,12 @@ mimes = OrderedDict(
     ]
 )
 
+trusted_archive_magics = OrderedDict(
+    [
+        ("ISO 9660", "iso"),
+    ]
+)
+
 magics = OrderedDict(
     [
         # ToDo msdos
@@ -485,9 +491,13 @@ def identify(f, check_shellcode: bool = False):
             if f.filename.endswith(extensions):
                 return package
 
-    # Trusted mimes should be applied before identifiers which could run on files within archives
+    # Trusted mimes and magics should be applied before identifiers which could run on files within archives
     if f.mime in trusted_archive_mimes:
         return trusted_archive_mimes[f.mime]
+
+    for magic_types in trusted_archive_magics:
+        if f.magic.startswith(magic_types):
+            return trusted_archive_magics[magic_types]
 
     for identifier in identifiers:
         package = identifier(f)

--- a/sflock/ident.py
+++ b/sflock/ident.py
@@ -65,6 +65,12 @@ file_extensions = OrderedDict(
     ]
 )
 
+trusted_archive_mimes = OrderedDict(
+    [
+        ("application/x-iso9660-image", "iso"),
+    ]
+)
+
 mimes = OrderedDict(
     [
         ("application/x-lzh-compressed", "lzh"),
@@ -478,6 +484,11 @@ def identify(f, check_shellcode: bool = False):
         for package, extensions in file_extensions.items():
             if f.filename.endswith(extensions):
                 return package
+
+    # Trusted mimes should be applied before identifiers which could run on files within archives
+    if f.mime in trusted_archive_mimes:
+        return trusted_archive_mimes[f.mime]
+
     for identifier in identifiers:
         package = identifier(f)
         if package:

--- a/tests/test_eml.py
+++ b/tests/test_eml.py
@@ -64,7 +64,7 @@ def test_eml_nested_eml():
     assert not files[0].children[1].selected
 
     assert files[1].relapath == b"att1"
-    assert "UTF-8 Unicode" in files[1].magic
+    assert "UTF-8 Unicode" in files[1].magic or "Unicode text, UTF-8 text" in files[1].magic
     assert files[1].contents == b"\xe6\x83\xa1\xe6\x84\x8f\xe8\xbb\x9f\xe9\xab\x94"
     assert files[1].package is None
     assert files[1].platform is None


### PR DESCRIPTION
This sample https://www.virustotal.com/gui/file/7134db54331eb7a48e890414ad893129832572675d61f1c917bcd448ae29bfc5 is identified as a JavaScript file when in fact it is an ISO that contains a JavaScript file. Therefore we should use the trusted mime/magic to ID these files.