### PR TITLE
process_directory: Don't read file contents into memory, open stream instead

### DIFF
--- a/sflock/abstracts.py
+++ b/sflock/abstracts.py
@@ -272,8 +272,12 @@ class File(object):
 
     @property
     def contents(self):
-        if self._contents is None and self.filepath:
-            self._contents = open(self.filepath, "rb").read()
+        if self._contents is None:
+            if self.filepath:
+                self._contents = open(self.filepath, "rb").read()
+            elif self._stream is not None:
+                self._stream.seek(0)
+                self._contents = self._stream.read()
         return self._contents
 
     @property


### PR DESCRIPTION
Hi!

Recently we see a lot of bloated malware samples, intentionally increased in size to make analysis more difficult and distributed to victims in compressed form. Reading them into memory while unpacking the archives is pretty painful. I noticed that sflock already has a very decent support for keeping only an opened stream in the File object and loading the contents on demand. Unfortunately, `Unpacker.process_directory` reads all the children contents into memory.

This PR fixes that by opening a stream instead of reading the contents. O_TEMPORARY flag is added in case of Windows to make children files deletable by further `shutil.rmtree` call. 

I have also added `close()` method that recursively closes all the stream objects. It should be called explicitly: calling it in `__del__` doesn't have much sense as file-like objects will be closed while GC'd anyway and someone may have additional references to child File objects - in that case they would be unexpectedly closed.
